### PR TITLE
Implement applications index page

### DIFF
--- a/src/app/[locale]/applications/page.tsx
+++ b/src/app/[locale]/applications/page.tsx
@@ -6,12 +6,15 @@ import FilterSelect from "@/app/components/FilterSelect";
 import ApplicationRow from "@/app/components/ApplicationRow";
 import { redirect } from "next/navigation";
 
-interface PageProps {
+interface ApplicationsPageProps {
   params: { locale: string };
   searchParams: { status?: string; month?: string };
 }
 
-export default async function ApplicationsPage({ params, searchParams }: PageProps) {
+export default async function ApplicationsPage({
+  params,
+  searchParams,
+}: ApplicationsPageProps) {
   const session = await getServerSession(authOptions);
   if (!session?.user) {
     redirect("/login");

--- a/src/app/[locale]/applications/page.tsx
+++ b/src/app/[locale]/applications/page.tsx
@@ -5,6 +5,7 @@ import Button from "@/app/components/Button";
 import FilterSelect from "@/app/components/FilterSelect";
 import ApplicationRow from "@/app/components/ApplicationRow";
 import { redirect } from "next/navigation";
+import type { Prisma } from "@prisma/client";
 
 interface ApplicationsPageProps {
   params: { locale: string };
@@ -20,7 +21,7 @@ export default async function ApplicationsPage({
     redirect("/login");
   }
 
-  const where: any = { userId: session!.user.id };
+  const where: Prisma.ApplicationWhereInput = { userId: session!.user.id };
   if (searchParams.status) {
     where.applicationStatus = searchParams.status;
   }

--- a/src/app/[locale]/applications/page.tsx
+++ b/src/app/[locale]/applications/page.tsx
@@ -1,7 +1,90 @@
-import React from "react";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { getServerSession } from "next-auth";
+import Button from "@/app/components/Button";
+import FilterSelect from "@/app/components/FilterSelect";
+import ApplicationRow from "@/app/components/ApplicationRow";
+import { redirect } from "next/navigation";
 
-const Application = () => {
-  return <div>Applications</div>;
-};
+interface PageProps {
+  params: { locale: string };
+  searchParams: { status?: string; month?: string };
+}
 
-export default Application;
+export default async function ApplicationsPage({ params, searchParams }: PageProps) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    redirect("/login");
+  }
+
+  const where: any = { userId: session!.user.id };
+  if (searchParams.status) {
+    where.applicationStatus = searchParams.status;
+  }
+  if (searchParams.month) {
+    const [yearStr, monthStr] = searchParams.month.split("-");
+    const year = parseInt(yearStr, 10);
+    const month = parseInt(monthStr, 10);
+    if (!isNaN(year) && !isNaN(month)) {
+      const start = new Date(year, month - 1, 1);
+      const end = new Date(year, month, 1);
+      where.applicationDate = { gte: start, lt: end };
+    }
+  }
+
+  const applications = await prisma.application.findMany({
+    where,
+    orderBy: { applicationDate: "desc" },
+  });
+
+  const currentYear = new Date().getFullYear();
+  const monthsOptions = Array.from({ length: 12 }, (_, i) => {
+    const label = new Date(currentYear, i).toLocaleString("default", { month: "long" });
+    const value = `${currentYear}-${String(i + 1).padStart(2, "0")}`;
+    return { value, label };
+  });
+
+  const statusOptions = [
+    { value: "APPLIED", label: "Applied" },
+    { value: "INTERVIEW", label: "Interview" },
+    { value: "OFFER", label: "Offer" },
+    { value: "REJECTED", label: "Rejected" },
+  ];
+
+  return (
+    <div className="py-8">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex gap-3">
+          <FilterSelect name="status" label="Status" options={statusOptions} />
+          <FilterSelect name="month" label="Month" options={monthsOptions} />
+        </div>
+        <Button href={`/${params.locale}/applications/new`}>New Application</Button>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm border">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="px-4 py-2 text-left">Job Title</th>
+              <th className="px-4 py-2 text-left">Status</th>
+              <th className="px-4 py-2 text-left">Application Date</th>
+              <th className="px-4 py-2" />
+            </tr>
+          </thead>
+          <tbody>
+            {applications.map((app) => (
+              <ApplicationRow key={app.id} application={app} locale={params.locale} />
+            ))}
+            {applications.length === 0 && (
+              <tr>
+                <td colSpan={4} className="text-center py-4">
+                  No applications found.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/ApplicationRow.tsx
+++ b/src/app/components/ApplicationRow.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link";
+import { Application } from "@prisma/client";
+
+type Props = {
+  application: Application;
+  locale: string;
+};
+
+export default function ApplicationRow({ application, locale }: Props) {
+  return (
+    <tr className="border-b hover:bg-gray-50">
+      <td className="px-4 py-2">
+        <Link
+          href={`/${locale}/applications/${application.id}`}
+          className="text-orange-600 hover:underline"
+        >
+          {application.jobTitle}
+        </Link>
+      </td>
+      <td className="px-4 py-2">{application.applicationStatus}</td>
+      <td className="px-4 py-2">
+        {application.applicationDate.toLocaleDateString()}
+      </td>
+      <td className="px-4 py-2 text-right">
+        <Link
+          href={`/${locale}/applications/${application.id}/edit`}
+          className="text-blue-600 hover:underline text-sm"
+        >
+          Edit
+        </Link>
+      </td>
+    </tr>
+  );
+}

--- a/src/app/components/Button.tsx
+++ b/src/app/components/Button.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+import { ButtonHTMLAttributes, ReactNode } from "react";
+
+type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
+  href?: string;
+  children: ReactNode;
+};
+
+export default function Button({ href, children, className = "", ...props }: Props) {
+  const base =
+    "inline-flex items-center rounded bg-orange-600 text-white px-4 py-2 text-sm font-medium hover:bg-orange-700";
+  if (href) {
+    return (
+      <Link href={href} className={`${base} ${className}`}>
+        {children}
+      </Link>
+    );
+  }
+  return (
+    <button className={`${base} ${className}`} {...props}>
+      {children}
+    </button>
+  );
+}

--- a/src/app/components/FilterSelect.tsx
+++ b/src/app/components/FilterSelect.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+export type Option = {
+  value: string;
+  label: string;
+};
+
+type Props = {
+  name: string;
+  label?: string;
+  options: Option[];
+};
+
+export default function FilterSelect({ name, label, options }: Props) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const params = new URLSearchParams(searchParams.toString());
+    const value = e.target.value;
+    if (value) {
+      params.set(name, value);
+    } else {
+      params.delete(name);
+    }
+    router.push(`${pathname}?${params.toString()}`);
+  };
+
+  const value = searchParams.get(name) ?? "";
+
+  return (
+    <label className="text-sm flex items-center gap-1">
+      {label && <span>{label}:</span>}
+      <select
+        className="border border-gray-300 rounded p-1"
+        value={value}
+        onChange={handleChange}
+      >
+        <option value="">All</option>
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable `Button` component
- add `FilterSelect` component for query-based filtering
- add `ApplicationRow` component for table rows
- build applications index page with filters and list

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684c2c7907cc832a860dcf43048be2cc